### PR TITLE
adding .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "yarn"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "master"
+    # Disable version updates for npm dependencies, only enabling security
+    # updates. See 
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "yarn"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "6.1.x"
+    # Disable version updates for npm dependencies, only enabling security
+    # updates. See 
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0
+

--- a/.github/dependabot.yml.tpl
+++ b/.github/dependabot.yml.tpl
@@ -1,0 +1,14 @@
+version: 2
+updates:
+{% for branch in branches %}
+  - package-ecosystem: "yarn"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "{{ branch }}"
+    # Disable version updates for npm dependencies, only enabling security
+    # updates. See 
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0
+
+{% endfor %}


### PR DESCRIPTION
Adding a `.github/dependabot.yml` file so that it tracks security issues in
currently maintained version-branches.

Also adding the `.github/dependabot.yml.tpl` template so that the
`.github/dependabot.yml` file can be updated with `release-tool` easily.