### PR TITLE
Support sending reminders to voters who didn't cast a vote

### DIFF
--- a/avRegistration/auth-method-service.js
+++ b/avRegistration/auth-method-service.js
@@ -564,7 +564,7 @@ angular.module('avRegistration')
             );
         };
 
-        authmethod.sendAuthCodes = function(eid, election, user_ids, auth_method, extra) {
+        authmethod.sendAuthCodes = function(eid, election, user_ids, auth_method, extra, filter) {
             var url = backendUrl + 'auth-event/'+eid+'/census/send_auth/';
             var data = {};
             if (angular.isDefined(election)) {
@@ -585,6 +585,9 @@ angular.module('avRegistration')
             }
             if (extra) {
               data["extra"] = extra;
+            }
+            if (angular.isDefined(filter)) {
+              data["filter"] = filter;
             }
             return $http.post(url, data);
         };

--- a/dist/appCommon-vmaster.js
+++ b/dist/appCommon-vmaster.js
@@ -279,12 +279,13 @@ angular.module("avRegistration").config(function() {}), angular.module("avRegist
             queryIds = "", queryIds = ids ? "&ids=" + ids.join("|") : "&only_parent_elections=true";
             return page_size && (queryIds += "&n=" + page_size), $http.get(backendUrl + "auth-event/?has_perms=" + perms + queryIds + "&order=-pk&page=" + page);
         },
-        sendAuthCodes: function(data, election, user_ids, auth_method, extra) {
+        sendAuthCodes: function(data, election, user_ids, auth_method, extra, filter) {
             var url = backendUrl + "auth-event/" + data + "/census/send_auth/", data = {};
             return angular.isDefined(election) && (data.msg = election.census.config.msg, "email" === auth_method && (data.subject = election.census.config.subject, 
             ConfigService.allowHtmlEmails && election.census.config.html_message && (data.html_message = election.census.config.html_message))), 
             angular.isDefined(user_ids) && (data["user-ids"] = user_ids), angular.isDefined(auth_method) && (data["auth-method"] = auth_method), 
-            extra && (data.extra = extra), $http.post(url, data);
+            extra && (data.extra = extra), angular.isDefined(filter) && (data.filter = filter), 
+            $http.post(url, data);
         },
         removeUsersIds: function(url, election, data, comment) {
             url = backendUrl + "auth-event/" + url + "/census/delete/", data = {


### PR DESCRIPTION
Enable sending emails/sms messages to part of the census, filtering by whether the voters have already casted their vote or not.

# Changes
* Modify the method `sendAuthCodes` to add a new optional filter argument. The possible filter values are `voted`and `not_voted`.