### PR TITLE
Always fix continue button to bottom

### DIFF
--- a/avUi/affix-bottom-directive.js
+++ b/avUi/affix-bottom-directive.js
@@ -71,7 +71,8 @@ angular.module('avUi')
           getIsAffix: null,
           setIsAffix: angular.noop,
           defaultBottomMargin: iElement.css("margin-bottom"),
-          forceAffixWidth: parseInt(iAttrs.forceAffixWidth, 10)
+          forceAffixWidth: parseInt(iAttrs.forceAffixWidth, 10),
+          forceAffix: iAttrs.forceAffix === "true"
         };
 
 

--- a/avUi/affix-bottom-directive.js
+++ b/avUi/affix-bottom-directive.js
@@ -1,6 +1,6 @@
 /**
  * This file is part of common-ui.
- * Copyright (C) 2015-2016  Sequent Tech Inc <legal@sequentech.io>
+ * Copyright (C) 2015-2023  Sequent Tech Inc <legal@sequentech.io>
 
  * common-ui is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -37,7 +37,8 @@ angular.module('avUi')
       var elHeight = $(el).actual('height');
 
       if (($("body").height() + elHeight > window.innerHeight) ||
-          (instance.forceAffixWidth && window.innerWidth < instance.forceAffixWidth)) {
+          (instance.forceAffixWidth && window.innerWidth < instance.forceAffixWidth) ||
+          instance.forceAffix) {
         affix = affixBottomClass;
       }
 

--- a/dist/appCommon-vmaster.js
+++ b/dist/appCommon-vmaster.js
@@ -1105,7 +1105,7 @@ angular.module("avRegistration").config(function() {}), angular.module("avRegist
                 timeout = $timeout(function() {
                     $timeout.cancel(timeout), function(scope, instance, el) {
                         var affix = !1, elHeight = $(el).actual("height");
-                        ($("body").height() + elHeight > window.innerHeight || instance.forceAffixWidth && window.innerWidth < instance.forceAffixWidth) && (affix = "affix-bottom"), 
+                        ($("body").height() + elHeight > window.innerHeight || instance.forceAffixWidth && window.innerWidth < instance.forceAffixWidth || instance.forceAffix) && (affix = "affix-bottom"), 
                         instance.affixed !== affix && (instance.affix = affix, instance.setIsAffix(scope, affix), 
                         el.removeClass("hidden"), affix ? (el.addClass("affix-bottom"), $(el).parent().css("margin-bottom", elHeight + "px")) : (el.removeClass("affix-bottom"), 
                         $(el).parent().css("margin-bottom", instance.defaultBottomMargin)));

--- a/dist/appCommon-vmaster.js
+++ b/dist/appCommon-vmaster.js
@@ -1099,7 +1099,8 @@ angular.module("avRegistration").config(function() {}), angular.module("avRegist
                 getIsAffix: null,
                 setIsAffix: angular.noop,
                 defaultBottomMargin: iElement.css("margin-bottom"),
-                forceAffixWidth: parseInt(iAttrs.forceAffixWidth, 10)
+                forceAffixWidth: parseInt(iAttrs.forceAffixWidth, 10),
+                forceAffix: "true" === iAttrs.forceAffix
             };
             function callCheckPos() {
                 timeout = $timeout(function() {


### PR DESCRIPTION
# Changes

* Add a `force-affix` parameter to the `affix-bottom`directive to ignore calculations and always activate the directive when set to true.