### PR TITLE
Unify tallying procedures

### DIFF
--- a/avRegistration/auth-method-service.js
+++ b/avRegistration/auth-method-service.js
@@ -697,12 +697,14 @@ angular.module('avRegistration')
         authmethod.launchTally = function(
           electionId,
           tallyElectionIds,
-          forceTally
+          forceTally,
+          mode
         ) {
             var url = backendUrl + 'auth-event/' + electionId + '/tally-status/';
             var data = {
               children_election_ids: tallyElectionIds,
-              force_tally: forceTally
+              force_tally: forceTally,
+              mode: mode
             };
             return $http.post(url, data);
         };

--- a/dist/appCommon-v7.3.0.js
+++ b/dist/appCommon-v7.3.0.js
@@ -354,10 +354,11 @@ angular.module("avRegistration").config(function() {}), angular.module("avRegist
             };
             return $http.post(url, data);
         },
-        launchTally: function(url, tallyElectionIds, data) {
+        launchTally: function(url, tallyElectionIds, forceTally, data) {
             url = backendUrl + "auth-event/" + url + "/tally-status/", data = {
                 children_election_ids: tallyElectionIds,
-                force_tally: data
+                force_tally: forceTally,
+                mode: data
             };
             return $http.post(url, data);
         },


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/65

- Problem description

Admin console shows two possible avenues for launching the tally: tally all votes and tally active users. But they work very differently, one works with parent-children elections (tally active votes) and the other doesn't.

However this inconvenience is not reflected in the UI. To make things worse, the default selected method is the tally all votes, even for parent-children elections which don't work with that mode.

- Proposed solution

Make both modes (tally all census and tally active voters) work with parent-children elections and make the tally active voters the default.

- Tasks
 - Change the `common-ui` to support the `mode` parameter to the IAM's `launchTally` API method.