### PR TITLE
Bump engine.io from 6.1.0 to 6.4.2 (#297)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "karma-ng-html2js-preprocessor": "^1.0.0"
   },
   "resolutions": {
-    "**/angular": "~1.8",
+    "**/engine.io": "6.1.0",
+    "**/angular": "1.8.3",
     "**/async": "3.2.2",
     "**/shelljs": ">=0.8.5",
     "**/json-schema": ">=0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,10 +1516,10 @@ engine.io-parser@~5.0.0:
   dependencies:
     "@socket.io/base64-arraybuffer" "~1.0.2"
 
-engine.io@~6.1.0:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.1.2.tgz#e7b9d546d90c62246ffcba4d88594be980d3855a"
-  integrity sha512-v/7eGHxPvO2AWsksyx2PUsQvBafuvqs0jJJQ0FdmJG1b9qIvgSbqDRGwNhfk2XHaTTbTXiC4quRE8Q9nRjsrQQ==
+engine.io@6.1.0, engine.io@~6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.1.0.tgz#459eab0c3724899d7b63a20c3a6835cf92857939"
+  integrity sha512-ErhZOVu2xweCjEfYcTdkCnEYUiZgkAcBBAhW4jbIvNG8SLU3orAqoJCiytZjYF7eTpVmmCrLDjLIEaPlUAs1uw==
   dependencies:
     "@types/cookie" "^0.4.1"
     "@types/cors" "^2.8.12"


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/75

Fixes https://github.com/sequentech/common-ui/security/dependabot/41