### PR TITLE
Fix Activity Log scrolling (#303)

### DIFF
--- a/avRegistration/auth-method-service.js
+++ b/avRegistration/auth-method-service.js
@@ -103,11 +103,11 @@ angular.module('avRegistration')
             // 1. initialize GET params
 
             if (size === 'max') {
-              params.size = 500;
+              params.n = 500;
             } else if (angular.isNumber(size) && size > 0 && size < 500) {
-              params.size = parseInt(size);
+              params.n = parseInt(size);
             } else {
-              params.size = 10;
+              params.n = 50;
             }
 
             if (!angular.isNumber(page)) {
@@ -141,11 +141,11 @@ angular.module('avRegistration')
             // 1. initialize GET params
 
             if (size === 'max') {
-              params.size = 500;
+              params.n = 500;
             } else if (angular.isNumber(size) && size > 0 && size < 500) {
-              params.size = parseInt(size);
+              params.n = parseInt(size);
             } else {
-              params.size = 10;
+              params.n = 50;
             }
 
             if (!angular.isNumber(page)) {

--- a/dist/appCommon-vmaster.js
+++ b/dist/appCommon-vmaster.js
@@ -46,7 +46,7 @@ angular.module("avRegistration").config(function() {}), angular.module("avRegist
         },
         getActivity: function(url, page, size, filterOptions, filterStr, receiver_id) {
             var params = {}, url = backendUrl + "auth-event/" + url + "/activity/";
-            return "max" === size ? params.size = 500 : angular.isNumber(size) && 0 < size && size < 500 ? params.size = parseInt(size) : params.size = 10, 
+            return "max" === size ? params.n = 500 : angular.isNumber(size) && 0 < size && size < 500 ? params.n = parseInt(size) : params.n = 50, 
             angular.isNumber(page) ? params.page = parseInt(page) : params.page = 1, angular.isNumber(receiver_id) && (params.receiver_id = receiver_id), 
             _.extend(params, filterOptions), filterStr && 0 < filterStr.length && (params.filter = filterStr), 
             $http.get(url, {
@@ -55,7 +55,7 @@ angular.module("avRegistration").config(function() {}), angular.module("avRegist
         },
         getBallotBoxes: function(url, page, size, filterOptions, filterStr) {
             var params = {}, url = backendUrl + "auth-event/" + url + "/ballot-box/";
-            return "max" === size ? params.size = 500 : angular.isNumber(size) && 0 < size && size < 500 ? params.size = parseInt(size) : params.size = 10, 
+            return "max" === size ? params.n = 500 : angular.isNumber(size) && 0 < size && size < 500 ? params.n = parseInt(size) : params.n = 50, 
             angular.isNumber(page) ? params.page = parseInt(page) : params.page = 1, _.extend(params, filterOptions), 
             filterStr && 0 < filterStr.length && (params.filter = filterStr), $http.get(url, {
                 params: params


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/90

The fix applied is simply returning more elements by default to ensure that the screen, even if big, either starts with scroll or has shown all the elements already.